### PR TITLE
Make it so that the nel script can be run from anywhere.

### DIFF
--- a/nel
+++ b/nel
@@ -1,2 +1,20 @@
 #!/bin/bash
+PRG="$0"
+CURDIR="`pwd`"
+# need this for relative symlinks
+while [ -h "$PRG" ] ; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`"/$link"
+  fi
+done
+SCRIPTDIR=`dirname "$PRG"`
+if [ x"${PYTHONPATH}" == x ]; then
+  export PYTHONPATH="${SCRIPTDIR}"
+else
+  export PYTHONPATH="${SCRIPTDIR}":${PYTHONPATH}
+fi
 python -m neleval.__main__ "$@"


### PR DESCRIPTION
Small addition to the nel script that will find the actual location of the script directory and add that location to the PYTHONPATH before running python. That way, the nel script (or a symbolic link)  can put in the PATH or the script can be run by specifying the full path like so /where/the/script/is/installed/nel .