### PR TITLE
Evaluation and micro/macro-averaging per doc/type/etc. (Fixes #19)

### DIFF
--- a/neleval/annotation.py
+++ b/neleval/annotation.py
@@ -404,7 +404,3 @@ class Measure(object):
         else:
             # This should not be reachable
             raise ValueError('Unexpected value for agg: %r' % self.agg)
-
-    def docs_to_contingency(self, system, gold):
-        return self.contingency([a for doc in system for a in doc.annotations],
-                                [a for doc in gold for a in doc.annotations])

--- a/neleval/annotation.py
+++ b/neleval/annotation.py
@@ -4,7 +4,7 @@
 from __future__ import division, print_function
 from collections import Sequence, defaultdict
 import operator
-from fractions import Fraction
+import warnings
 
 from .utils import unicode
 
@@ -175,9 +175,7 @@ class Candidate(object):
 
 
 class Measure(object):
-    __slots__ = ['key', 'filter', 'filter_fn', 'agg']
-
-    def __init__(self, key, filter=None, agg='sets-micro'):
+    def __init__(self, key, filter=None, agg='sets'):
         """
         key : list of fields for mention comparison
         filter : a function or attribute name to select evaluated annotations
@@ -191,10 +189,18 @@ class Measure(object):
             assert isinstance(filter, str)
             filter = operator.attrgetter(filter)
         self.filter_fn = filter
+        if agg.endswith('-micro'):
+            self.display_agg = agg
+            agg = agg[:-6]
+            warnings.warn('`{}-micro\' aggregate has been renamed to '
+                          '`{}\' and will be removed in a future '
+                          'release.'.format(agg),
+                          DeprecationWarning)
         self.agg = agg
 
     def __str__(self):
-        return '{}:{}:{}'.format(self.agg, self.filter, '+'.join(self.key))
+        return '{}:{}:{}'.format(getattr(self, 'display_agg', self.agg),
+                                 self.filter, '+'.join(self.key))
 
     @classmethod
     def from_string(cls, s):
@@ -209,11 +215,10 @@ class Measure(object):
         return ('{0.__class__.__name__}('
                 '{0.key!r}, {0.filter!r}, {0.agg!r})'.format(self))
 
-    # TODO: variants macro-averaged across docs
-    NON_CLUSTERING_AGG = (['sets-micro'] +
-                          ['overlap-%s%s-micro' % (p1, p2)
-                           for p1 in ('sum', 'max')
-                           for p2 in ('sum', 'max')])
+    NON_CLUSTERING_AGG = ('sets',) + tuple(
+        ['overlap-%s%s' % (p1, p2)
+         for p1 in ('sum', 'max')
+         for p2 in ('sum', 'max')])
 
     @property
     def is_clustering(self):

--- a/neleval/configs.py
+++ b/neleval/configs.py
@@ -241,7 +241,7 @@ class ListMeasures(object):
         ret += '\n\n'
         ret += _wrap('In all measures, a set of tuples corresponding to Key '
                      'Fields is produced from annotations matching Filter. '
-                     'Aggregation with sets-micro compares gold and predicted '
+                     'Aggregation with `sets\' compares gold and predicted '
                      'tuple sets directly; coreference aggregates compare '
                      'tuples clustered by their assigned entity ID.')
         ret += '\n\n'

--- a/neleval/evaluate.py
+++ b/neleval/evaluate.py
@@ -33,7 +33,7 @@ class Evaluate(object):
 
     def __init__(self, system, gold=None,
                  measures=DEFAULT_MEASURE_SET,
-                 fmt='none', group_by=None, no_groups=False):
+                 fmt='none', group_by=None, overall=False):
         """
         system - system output
         gold - gold standard
@@ -54,7 +54,7 @@ class Evaluate(object):
         self.format = self.FMTS[fmt] if fmt is not callable else fmt
         self.doc_pairs = list(self.iter_pairs(self.system, self.gold))
         self.group_by = group_by
-        self.no_groups = no_groups
+        self.overall = overall
 
     @classmethod
     def iter_pairs(self, system, gold):
@@ -109,7 +109,7 @@ class Evaluate(object):
                              )
                 measure_mats.append((group, mat))
 
-                if self.group_by and not self.no_groups:
+                if self.group_by and not self.overall:
                     name = name_fmt.format(measure=measure,
                                            group=[json.dumps(v) for v in group])
                     self.results[name] = mat.results
@@ -148,7 +148,11 @@ class Evaluate(object):
                             'Multiple --group-by may be used.  '
                             'E.g. -b docid -b type.  '
                             'NB: micro-average may not equal overall score.')
-        p.add_argument('--no-groups', default=False, action='store_true',
+        p.add_argument('--by-doc', dest='group_by', action='append_const',
+                       const='docid', help='Alias for -b docid')
+        p.add_argument('--by-type', dest='group_by', action='append_const',
+                       const='type', help='Alias for -b type')
+        p.add_argument('--overall', default=False, action='store_true',
                        help='With --group-by, report only overall, not per-group results')
         p.set_defaults(cls=cls)
         return p


### PR DESCRIPTION
This PR introduces options to `evaluate` that allow the calculation of scores for each document or type etc. independently, then aggregates these using micro and macro-average. Fixes #19 

Examples:

```
$ ./nel evaluate -m mention_ceaf -b type -g tac15data/{gold,sys}.tsv
ptp	fp	rtp	fn	precis	recall	fscore	measure
27	88	27	407	0.235	0.062	0.098	mention_ceaf;type="FAC/NAM"
5675	2171	5675	5883	0.723	0.491	0.585	mention_ceaf;type="GPE/NAM"
245	259	245	1243	0.486	0.165	0.246	mention_ceaf;type="LOC/NAM"
2024	2799	2024	3509	0.420	0.366	0.391	mention_ceaf;type="ORG/NAM"
5729	2697	5729	5714	0.680	0.501	0.577	mention_ceaf;type="PER/NAM"
367	1010	367	1691	0.267	0.178	0.214	mention_ceaf;type="PER/NOM"
2344.500	1504.000	2344.500	3074.500	0.468	0.294	0.352	mention_ceaf;type=<macro>
14067	9024	14067	18447	0.609	0.433	0.506	mention_ceaf;type=<micro>
```

Aggregate over multiple fields; aggregates only:
```
$ ./nel evaluate -m mention_ceaf -b docid -b type --no-groups -g tac15data/{gold,sys}.tsv
neleval/evaluate.py:271: StrictMetricWarning: Strict P/R defaulting to zero score for zero denominator
  StrictMetricWarning)
ptp	fp	rtp	fn	precis	recall	fscore	measure
30.894	15.381	30.894	34.265	0.627	0.504	0.543	mention_ceaf;docid=<macro>;type=<micro>
2569.333	1279.167	2569.333	2849.667	0.527	0.328	0.393	mention_ceaf;docid=<micro>;type=<macro>
15416	7675	15416	17098	0.668	0.474	0.554	mention_ceaf;docid=<micro>;type=<micro>
```

TODO:
* [x] perhaps find a better name than `--no-groups`
* [x] rename `sets-micro` aggregate to `sets`?
* [ ] test?
* [ ] ~~support gold frequency-weighted macro-average?~~
* [ ] document on wiki

Ping @shyamupa

<!---
@huboard:{"order":15.5}
-->
