### PR TITLE
Fix usage of deprecated np.bool and np.int 

### DIFF
--- a/neleval/munkres.py
+++ b/neleval/munkres.py
@@ -83,8 +83,8 @@ class _HungarianState(object):
 
         # At this point, m >= n.
         n, m = self.C.shape
-        self.row_uncovered = np.ones(n, dtype=np.bool)
-        self.col_uncovered = np.ones(m, dtype=np.bool)
+        self.row_uncovered = np.ones(n, dtype=bool)
+        self.col_uncovered = np.ones(m, dtype=bool)
         self.Z0_r = 0
         self.Z0_c = 0
         self.path = np.zeros((n + m, 2), dtype=int)
@@ -187,9 +187,9 @@ def _step4(state):
     left. Save the smallest uncovered value and Go to Step 6.
     """
     # We convert to int as numpy operations are faster on int
-    C = (state.C == 0).astype(np.int)
+    C = (state.C == 0).astype(int)
     covered_C = C * state.row_uncovered[:, np.newaxis]
-    covered_C *= state.col_uncovered.astype(np.int)
+    covered_C *= state.col_uncovered.astype(int)
     n = state.C.shape[0]
     m = state.C.shape[1]
     while True:
@@ -210,8 +210,7 @@ def _step4(state):
                 col = star_col
                 state.row_uncovered[row] = False
                 state.col_uncovered[col] = True
-                covered_C[:, col] = C[:, col] * (
-                    state.row_uncovered.astype(np.int))
+                covered_C[:, col] = C[:, col] * (state.row_uncovered.astype(int))
                 covered_C[row] = 0
 
 


### PR DESCRIPTION
`np.bool` and `np.int` are used in neleval, but have been deprecated for a while. They now raise an AttributeError, which is problematic. I replaced `np.bool` and `np.int` by `bool` and `int`, as recommended in the numpy doc (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)